### PR TITLE
Feature / Limit the number of scores in the feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -26,6 +26,20 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'should limit the number of scores in the feed' do
+      35.times do
+        create(:score, user: @user1, total_score: 79, played_at: '2024-08-01')
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
Fixes: [AACraiu#21](https://github.com/AACraiu/golfr_backend/issues/21)

**Changes**

Added a test that checks if there are 25 score cards displayed on the feed and after that i added the limit method which made the test pass.

**Before**

<img width="868" alt="Screenshot 2024-08-01 at 13 42 41" src="https://github.com/user-attachments/assets/286895d3-7954-4ada-86be-1150ac8908a1">


**After**

<img width="555" alt="Screenshot 2024-08-01 at 13 46 57" src="https://github.com/user-attachments/assets/639752b0-b3f3-45c6-93e5-3cd46dfa2ab0">

